### PR TITLE
Extract sudo calls from bash scripts in bin/

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -28,6 +28,7 @@ PROJECT_PATH=$( pwd )
 # load helpers
 source "${PROJECT_PATH}"/bin/util/echos.sh
 source "${PROJECT_PATH}"/bin/util/helpers.sh
+source "${PROJECT_PATH}"/bin/util/commands.sh
 
 # env vars
 I2P_LOGLEVEL=${I2P_LOGLEVEL:-none}
@@ -80,7 +81,7 @@ cd "${PATH_DOMAIN}"
 
 if [[ -f ./diva.yml ]]
 then
-  sudo docker compose -f ./diva.yml down
+  as_root docker compose -f ./diva.yml down
 fi
 
 if [[ ${PURGE} -gt 0 ]]
@@ -91,13 +92,13 @@ then
 
   if [[ -f ./diva.yml ]]
   then
-    sudo docker compose -f ./diva.yml down --volumes
+    as_root docker compose -f ./diva.yml down --volumes
   fi
 
-  sudo rm -rf "${PATH_DOMAIN}"/genesis/*
-  sudo rm -rf "${PATH_DOMAIN}"/keys/*
-  sudo rm -rf "${PATH_DOMAIN}"/state/*
-  sudo rm -rf "${PATH_DOMAIN}"/blockstore/*
+  as_root rm -rf "${PATH_DOMAIN}"/genesis/*
+  as_root rm -rf "${PATH_DOMAIN}"/keys/*
+  as_root rm -rf "${PATH_DOMAIN}"/state/*
+  as_root rm -rf "${PATH_DOMAIN}"/blockstore/*
 fi
 
 if [[ ! -f genesis/local.config ]]
@@ -106,12 +107,12 @@ then
 
   if [[ -f ./genesis-i2p.yml ]]
   then
-    sudo SIZE_NETWORK=${SIZE_NETWORK} docker compose -f ./genesis-i2p.yml down --volumes
+    SIZE_NETWORK=${SIZE_NETWORK} as_root docker compose -f ./genesis-i2p.yml down --volumes
   fi
 
   cp "${PROJECT_PATH}"/build/genesis-i2p.yml ./genesis-i2p.yml
-  sudo SIZE_NETWORK=${SIZE_NETWORK} docker compose -f ./genesis-i2p.yml pull
-  sudo SIZE_NETWORK=${SIZE_NETWORK} docker compose -f ./genesis-i2p.yml up -d
+  SIZE_NETWORK=${SIZE_NETWORK} as_root docker compose -f ./genesis-i2p.yml pull
+  SIZE_NETWORK=${SIZE_NETWORK} as_root docker compose -f ./genesis-i2p.yml up -d
 
   running "Waiting for key generation"
   # wait until all keys are created
@@ -121,7 +122,7 @@ then
   done
 
   # shut down the genesis container and clean up
-  sudo SIZE_NETWORK=${SIZE_NETWORK} docker compose -f ./genesis-i2p.yml down --volumes
+  SIZE_NETWORK=${SIZE_NETWORK} as_root docker compose -f ./genesis-i2p.yml down --volumes
   rm ./genesis-i2p.yml
 
   # handle joining

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -28,17 +28,18 @@ PROJECT_PATH=$( pwd )
 # load helpers
 source "${PROJECT_PATH}"/bin/util/echos.sh
 source "${PROJECT_PATH}"/bin/util/helpers.sh
+source "${PROJECT_PATH}"/bin/util/commands.sh
 
 BASE_DOMAIN=${BASE_DOMAIN:-}
 
 if [[ ${BASE_DOMAIN} = "*" ]]
 then
   info "Removing ${PROJECT_PATH}/build/domains/*"
-  sudo rm -rf "${PROJECT_PATH}"/build/domains/*
+  as_root rm -rf "${PROJECT_PATH}"/build/domains/*
 elif [[ -n ${BASE_DOMAIN} && -d ${PROJECT_PATH}/build/domains/${BASE_DOMAIN} ]]
 then
   info "Removing ${PROJECT_PATH}/build/domains/${BASE_DOMAIN}"
-  sudo rm -rf "${PROJECT_PATH}"/build/domains/"${BASE_DOMAIN}"
+  as_root rm -rf "${PROJECT_PATH}"/build/domains/"${BASE_DOMAIN}"
 else
   warn "Set BASE_DOMAIN to a existing directory name (see domains directory)"
   exit 1

--- a/bin/halt.sh
+++ b/bin/halt.sh
@@ -28,6 +28,7 @@ PROJECT_PATH=$( pwd )
 # load helpers
 source "${PROJECT_PATH}"/bin/util/echos.sh
 source "${PROJECT_PATH}"/bin/util/helpers.sh
+source "${PROJECT_PATH}"/bin/util/commands.sh
 
 # env vars
 DIVA_TESTNET=${DIVA_TESTNET:-0}
@@ -54,5 +55,5 @@ then
 fi
 
 running "Halting ${PATH_DOMAIN}"
-sudo docker compose -f ./diva.yml down
+as_root docker compose -f ./diva.yml down
 ok "Halted ${PATH_DOMAIN}"

--- a/bin/purge.sh
+++ b/bin/purge.sh
@@ -28,6 +28,7 @@ PROJECT_PATH=$( pwd )
 # load helpers
 source "${PROJECT_PATH}/bin/util/echos.sh"
 source "${PROJECT_PATH}/bin/util/helpers.sh"
+source "${PROJECT_PATH}/bin/util/commands.sh"
 
 # env vars
 DIVA_TESTNET=${DIVA_TESTNET:-0}
@@ -68,6 +69,6 @@ warn "If you want to keep the data, run a backup first."
 confirm "Do you want to DELETE all local diva data (y/N)?" || exit 5
 
 running "Purging ${PATH_DOMAIN}"
-sudo docker compose -f ./diva.yml down --volumes
+as_root docker compose -f ./diva.yml down --volumes
 BASE_DOMAIN=${BASE_DOMAIN} "${PROJECT_PATH}"/bin/clean.sh
 ok "Purged ${PATH_DOMAIN}"

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -28,6 +28,7 @@ PROJECT_PATH=$( pwd )
 # load helpers
 source "${PROJECT_PATH}/bin/util/echos.sh"
 source "${PROJECT_PATH}/bin/util/helpers.sh"
+source "${PROJECT_PATH}/bin/util/commands.sh"
 
 # env vars
 DIVA_TESTNET=${DIVA_TESTNET:-0}
@@ -65,8 +66,8 @@ then
 fi
 
 running "Pulling ${PATH_DOMAIN}"
-sudo docker compose -f ./diva.yml pull
+as_root docker compose -f ./diva.yml pull
 
 running "Starting ${PATH_DOMAIN}"
-sudo NO_BOOTSTRAPPING="${NO_BOOTSTRAPPING}" docker compose -f ./diva.yml up -d
+NO_BOOTSTRAPPING="${NO_BOOTSTRAPPING}" as_root docker compose -f ./diva.yml up -d
 ok "Started ${PATH_DOMAIN}"

--- a/bin/util/commands.sh
+++ b/bin/util/commands.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+SUDO_CMD="${SUDO_CMD-sudo}"
+
+function as_root() {
+    echo "Running privileged command"
+    echo " $SUDO_CMD " "$@"
+
+    if [[ -n "$SUDO_CMD" ]]; then
+        "$SUDO_CMD" "$@"
+    else
+        "$@"
+    fi
+}
+


### PR DESCRIPTION
On some systems the user I want to run these scripts on are not in the sudoers group, but might be in the docker group.

Additionally, this is useful to check whether all of these elevated commands are actually needed.

Using this commit I'm testing this by calling the script setting the environment variable SUDO_CMD to an empty string. For example:

    SUDO_CMD= bin/build.sh

Not sure if this is anything worthwhile, but here's my branch :)