### PR TITLE
add npm install to build.sh

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -136,6 +136,8 @@ fi
 
 running "Creating diva.yml file"
 
+npm install
+
 tsc
 
 JOIN_NETWORK=${JOIN_NETWORK} \


### PR DESCRIPTION
When I first ran the build script I didn't have npm installed but had tsc, I then got the following error

     ⇒  Creating diva.yml file…
    ../../build.ts:20:16 - error TS2307: Cannot find module 'fs' or its corresponding type declarations.

    20 import fs from 'fs';

With more similar errors following.

This occured because the node dependencies were not installed. I therefore installed npm and added an npm install to the script.

We might need to pass further options because we want this scripted nicely, but for now I propose just adding an npm install call before the call to the typescript compiler tsc.